### PR TITLE
Fix AMD real file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,25 @@
     <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     <requirejs>
         {
-            "paths": {
-                "dropzone": "dropzone"
+          "paths": {
+              "dropzone": "dropzone-amd-module"
+          },
+          "shims": {
+            "dropzone": {
+              "deps": ["jquery"]
             }
+          }
         }
     </requirejs>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jquery</artifactId>
+      <version>2.2.2</version>
+    </dependency>
+  </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
There is a specific file for the AMD module: http://www.dropzonejs.com/#with-requirejs and it needs jQuery to work.

@jamesward: Could you cut a release with this? I would be more than happy to help you for this..
